### PR TITLE
[MVC 구현하기 - 2단계] 로빈(임수빈) 미션 제출합니다.

### DIFF
--- a/app/src/main/java/com/techcourse/ControllerHandlerMappingAdaptor.java
+++ b/app/src/main/java/com/techcourse/ControllerHandlerMappingAdaptor.java
@@ -1,0 +1,27 @@
+package com.techcourse;
+
+import com.interface21.webmvc.servlet.mvc.asis.Controller;
+import com.interface21.webmvc.servlet.mvc.asis.ControllerHandlerAdaptor;
+import com.interface21.webmvc.servlet.mvc.tobe.HandlerAdaptor;
+import com.interface21.webmvc.servlet.mvc.tobe.HandlerMapping;
+import jakarta.servlet.http.HttpServletRequest;
+
+public class ControllerHandlerMappingAdaptor implements HandlerMapping {
+
+    private final ManualHandlerMapping handlerMapping;
+
+    public ControllerHandlerMappingAdaptor(ManualHandlerMapping handlerMapping) {
+        this.handlerMapping = handlerMapping;
+    }
+
+    @Override
+    public void initialize() {
+        handlerMapping.initialize();
+    }
+
+    @Override
+    public HandlerAdaptor getHandler(HttpServletRequest request) {
+        Controller handler = handlerMapping.getHandler(request.getRequestURI());
+        return new ControllerHandlerAdaptor(handler);
+    }
+}

--- a/app/src/main/java/com/techcourse/DispatcherServlet.java
+++ b/app/src/main/java/com/techcourse/DispatcherServlet.java
@@ -1,12 +1,18 @@
 package com.techcourse;
 
+import com.interface21.webmvc.servlet.ModelAndView;
+import com.interface21.webmvc.servlet.View;
+import com.interface21.webmvc.servlet.mvc.asis.Controller;
+import com.interface21.webmvc.servlet.mvc.tobe.AnnotationHandlerMapping;
+import com.interface21.webmvc.servlet.mvc.tobe.HandlerExecution;
+import com.interface21.webmvc.servlet.view.JspView;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.interface21.webmvc.servlet.view.JspView;
 
 public class DispatcherServlet extends HttpServlet {
 
@@ -14,6 +20,7 @@ public class DispatcherServlet extends HttpServlet {
     private static final Logger log = LoggerFactory.getLogger(DispatcherServlet.class);
 
     private ManualHandlerMapping manualHandlerMapping;
+    private AnnotationHandlerMapping annotationHandlerMapping;
 
     public DispatcherServlet() {
     }
@@ -22,24 +29,39 @@ public class DispatcherServlet extends HttpServlet {
     public void init() {
         manualHandlerMapping = new ManualHandlerMapping();
         manualHandlerMapping.initialize();
+        annotationHandlerMapping = new AnnotationHandlerMapping(getPackageName());
+        annotationHandlerMapping.initialize();
+    }
+
+    private String getPackageName() {
+        return getClass().getPackageName();
     }
 
     @Override
-    protected void service(final HttpServletRequest request, final HttpServletResponse response) throws ServletException {
+    protected void service(final HttpServletRequest request, final HttpServletResponse response)
+            throws ServletException {
         final String requestURI = request.getRequestURI();
         log.debug("Method : {}, Request URI : {}", request.getMethod(), requestURI);
 
         try {
-            final var controller = manualHandlerMapping.getHandler(requestURI);
-            final var viewName = controller.execute(request, response);
-            move(viewName, request, response);
+            serviceByManual(request, response, requestURI);
+        } catch (NullPointerException e) {
+            serviceByAnnotation(request, response);
         } catch (Throwable e) {
             log.error("Exception : {}", e.getMessage(), e);
             throw new ServletException(e.getMessage());
         }
     }
 
-    private void move(final String viewName, final HttpServletRequest request, final HttpServletResponse response) throws Exception {
+    private void serviceByManual(HttpServletRequest request, HttpServletResponse response, String requestURI)
+            throws Exception {
+        Controller controller = manualHandlerMapping.getHandler(requestURI);
+        final var viewName = controller.execute(request, response);
+        move(viewName, request, response);
+    }
+
+    private void move(final String viewName, final HttpServletRequest request, final HttpServletResponse response)
+            throws Exception {
         if (viewName.startsWith(JspView.REDIRECT_PREFIX)) {
             response.sendRedirect(viewName.substring(JspView.REDIRECT_PREFIX.length()));
             return;
@@ -47,5 +69,30 @@ public class DispatcherServlet extends HttpServlet {
 
         final var requestDispatcher = request.getRequestDispatcher(viewName);
         requestDispatcher.forward(request, response);
+    }
+
+    private void serviceByAnnotation(HttpServletRequest request, HttpServletResponse response) {
+        HandlerExecution handlerExecution = (HandlerExecution) annotationHandlerMapping.getHandler(request);
+        ModelAndView modelAndView = executeHandlerExecution(handlerExecution, request, response);
+        move(modelAndView, request, response);
+    }
+
+    private ModelAndView executeHandlerExecution(HandlerExecution handlerExecution, HttpServletRequest request,
+                                                 HttpServletResponse response) {
+        try {
+            return handlerExecution.handle(request, response);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void move(ModelAndView modelAndView, HttpServletRequest request, HttpServletResponse response) {
+        Map<String, Object> model = modelAndView.getModel();
+        View view = modelAndView.getView();
+        try {
+            view.render(model, request, response);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/app/src/main/java/com/techcourse/DispatcherServlet.java
+++ b/app/src/main/java/com/techcourse/DispatcherServlet.java
@@ -2,10 +2,10 @@ package com.techcourse;
 
 import com.interface21.webmvc.servlet.ModelAndView;
 import com.interface21.webmvc.servlet.View;
-import com.interface21.webmvc.servlet.mvc.asis.Controller;
 import com.interface21.webmvc.servlet.mvc.tobe.AnnotationHandlerMapping;
-import com.interface21.webmvc.servlet.mvc.tobe.HandlerExecution;
-import com.interface21.webmvc.servlet.view.JspView;
+import com.interface21.webmvc.servlet.mvc.tobe.AnnotationHandlerMappingAdaptor;
+import com.interface21.webmvc.servlet.mvc.tobe.CompositeHandlerMapping;
+import com.interface21.webmvc.servlet.mvc.tobe.HandlerAdaptor;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
@@ -19,18 +19,22 @@ public class DispatcherServlet extends HttpServlet {
     private static final long serialVersionUID = 1L;
     private static final Logger log = LoggerFactory.getLogger(DispatcherServlet.class);
 
-    private ManualHandlerMapping manualHandlerMapping;
-    private AnnotationHandlerMapping annotationHandlerMapping;
+    private CompositeHandlerMapping handlerMapping;
 
     public DispatcherServlet() {
     }
 
     @Override
     public void init() {
-        manualHandlerMapping = new ManualHandlerMapping();
-        manualHandlerMapping.initialize();
-        annotationHandlerMapping = new AnnotationHandlerMapping(getPackageName());
-        annotationHandlerMapping.initialize();
+        ManualHandlerMapping manualHandlerMapping = new ManualHandlerMapping();
+        AnnotationHandlerMapping annotationHandlerMapping = new AnnotationHandlerMapping(getPackageName());
+        var controllerHandlerMappingAdaptor = new ControllerHandlerMappingAdaptor(manualHandlerMapping);
+        var annotationHandlerMappingAdaptor = new AnnotationHandlerMappingAdaptor(annotationHandlerMapping);
+
+        this.handlerMapping = new CompositeHandlerMapping(
+                controllerHandlerMappingAdaptor,
+                annotationHandlerMappingAdaptor
+        );
     }
 
     private String getPackageName() {
@@ -42,57 +46,20 @@ public class DispatcherServlet extends HttpServlet {
             throws ServletException {
         final String requestURI = request.getRequestURI();
         log.debug("Method : {}, Request URI : {}", request.getMethod(), requestURI);
-
         try {
-            serviceByManual(request, response, requestURI);
-        } catch (NullPointerException e) {
-            serviceByAnnotation(request, response);
+            HandlerAdaptor handler = handlerMapping.getHandler(request);
+            ModelAndView modelAndView = handler.handle(request, response);
+            render(modelAndView, request, response);
         } catch (Throwable e) {
             log.error("Exception : {}", e.getMessage(), e);
             throw new ServletException(e.getMessage());
         }
     }
 
-    private void serviceByManual(HttpServletRequest request, HttpServletResponse response, String requestURI)
+    private void render(ModelAndView modelAndView, HttpServletRequest request, HttpServletResponse response)
             throws Exception {
-        Controller controller = manualHandlerMapping.getHandler(requestURI);
-        final var viewName = controller.execute(request, response);
-        move(viewName, request, response);
-    }
-
-    private void move(final String viewName, final HttpServletRequest request, final HttpServletResponse response)
-            throws Exception {
-        if (viewName.startsWith(JspView.REDIRECT_PREFIX)) {
-            response.sendRedirect(viewName.substring(JspView.REDIRECT_PREFIX.length()));
-            return;
-        }
-
-        final var requestDispatcher = request.getRequestDispatcher(viewName);
-        requestDispatcher.forward(request, response);
-    }
-
-    private void serviceByAnnotation(HttpServletRequest request, HttpServletResponse response) {
-        HandlerExecution handlerExecution = (HandlerExecution) annotationHandlerMapping.getHandler(request);
-        ModelAndView modelAndView = executeHandlerExecution(handlerExecution, request, response);
-        move(modelAndView, request, response);
-    }
-
-    private ModelAndView executeHandlerExecution(HandlerExecution handlerExecution, HttpServletRequest request,
-                                                 HttpServletResponse response) {
-        try {
-            return handlerExecution.handle(request, response);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private void move(ModelAndView modelAndView, HttpServletRequest request, HttpServletResponse response) {
         Map<String, Object> model = modelAndView.getModel();
         View view = modelAndView.getView();
-        try {
-            view.render(model, request, response);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        view.render(model, request, response);
     }
 }

--- a/app/src/main/java/com/techcourse/ManualHandlerMapping.java
+++ b/app/src/main/java/com/techcourse/ManualHandlerMapping.java
@@ -1,13 +1,15 @@
 package com.techcourse;
 
-import com.techcourse.controller.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import com.interface21.webmvc.servlet.mvc.asis.Controller;
 import com.interface21.webmvc.servlet.mvc.asis.ForwardController;
-
+import com.techcourse.controller.LoginController;
+import com.techcourse.controller.LoginViewController;
+import com.techcourse.controller.LogoutController;
+import com.techcourse.controller.RegisterViewController;
 import java.util.HashMap;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ManualHandlerMapping {
 
@@ -21,7 +23,6 @@ public class ManualHandlerMapping {
         controllers.put("/login/view", new LoginViewController());
         controllers.put("/logout", new LogoutController());
         controllers.put("/register/view", new RegisterViewController());
-        controllers.put("/register", new RegisterController());
 
         log.info("Initialized Handler Mapping!");
         controllers.keySet()

--- a/app/src/main/java/com/techcourse/controller/RegisterController.java
+++ b/app/src/main/java/com/techcourse/controller/RegisterController.java
@@ -1,21 +1,26 @@
 package com.techcourse.controller;
 
+import com.interface21.context.stereotype.Controller;
+import com.interface21.web.bind.annotation.RequestMapping;
+import com.interface21.web.bind.annotation.RequestMethod;
+import com.interface21.webmvc.servlet.ModelAndView;
+import com.interface21.webmvc.servlet.view.JspView;
 import com.techcourse.domain.User;
 import com.techcourse.repository.InMemoryUserRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import com.interface21.webmvc.servlet.mvc.asis.Controller;
 
-public class RegisterController implements Controller {
+@Controller
+public class RegisterController {
 
-    @Override
-    public String execute(final HttpServletRequest req, final HttpServletResponse res) throws Exception {
+    @RequestMapping(value = "/register", method = RequestMethod.POST)
+    public ModelAndView save(HttpServletRequest req, HttpServletResponse res) {
         final var user = new User(2,
                 req.getParameter("account"),
                 req.getParameter("password"),
                 req.getParameter("email"));
         InMemoryUserRepository.save(user);
 
-        return "redirect:/index.jsp";
+        return new ModelAndView(new JspView("redirect:/index.jsp"));
     }
 }

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/AbstractView.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/AbstractView.java
@@ -1,0 +1,10 @@
+package com.interface21.webmvc.servlet;
+
+public abstract class AbstractView implements View {
+
+    protected final String viewName;
+
+    public AbstractView(String viewName) {
+        this.viewName = viewName;
+    }
+}

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/asis/Controller.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/asis/Controller.java
@@ -1,8 +1,14 @@
 package com.interface21.webmvc.servlet.mvc.asis;
 
+import com.interface21.webmvc.servlet.AbstractView;
+import com.interface21.webmvc.servlet.view.JspView;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 public interface Controller {
     String execute(final HttpServletRequest req, final HttpServletResponse res) throws Exception;
+
+    default Class<? extends AbstractView> getSupportViewClass() {
+        return JspView.class;
+    }
 }

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/asis/ControllerHandlerAdaptor.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/asis/ControllerHandlerAdaptor.java
@@ -1,0 +1,34 @@
+package com.interface21.webmvc.servlet.mvc.asis;
+
+import com.interface21.webmvc.servlet.AbstractView;
+import com.interface21.webmvc.servlet.ModelAndView;
+import com.interface21.webmvc.servlet.mvc.tobe.HandlerAdaptor;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.lang.reflect.Constructor;
+
+public class ControllerHandlerAdaptor implements HandlerAdaptor {
+
+    private final Controller controller;
+
+    public ControllerHandlerAdaptor(Object handler) {
+        if (!isSupport(handler)) {
+            throw new RuntimeException("지원하지 않는 핸들러 입니다.");
+        }
+        this.controller = (Controller) handler;
+    }
+
+    @Override
+    public boolean isSupport(Object handler) {
+        return handler instanceof Controller;
+    }
+
+    @Override
+    public ModelAndView handle(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        String viewName = controller.execute(request, response);
+        Class<? extends AbstractView> viewClass = controller.getSupportViewClass();
+        Constructor<? extends AbstractView> constructor = viewClass.getConstructor(viewName.getClass());
+        AbstractView view = constructor.newInstance(viewName);
+        return new ModelAndView(view);
+    }
+}

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/AnnotationHandlerAdaptor.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/AnnotationHandlerAdaptor.java
@@ -1,0 +1,27 @@
+package com.interface21.webmvc.servlet.mvc.tobe;
+
+import com.interface21.webmvc.servlet.ModelAndView;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class AnnotationHandlerAdaptor implements HandlerAdaptor {
+
+    private final HandlerExecution handlerExecution;
+
+    public AnnotationHandlerAdaptor(Object handler) {
+        if (!isSupport(handler)) {
+            throw new RuntimeException("지원하지 않는 핸들러 입니다.");
+        }
+        this.handlerExecution = (HandlerExecution) handler;
+    }
+
+    @Override
+    public boolean isSupport(Object handler) {
+        return handler instanceof HandlerExecution;
+    }
+
+    @Override
+    public ModelAndView handle(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        return handlerExecution.handle(request, response);
+    }
+}

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/AnnotationHandlerMapping.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/AnnotationHandlerMapping.java
@@ -82,12 +82,12 @@ public class AnnotationHandlerMapping {
     }
 
     private void addHandlerExecution(HandlerKey handlerKey, HandlerExecution handlerExecution) {
-        validateDuplicateHanderKey(handlerKey);
+        validateDuplicateHandlerKey(handlerKey);
         handlerExecutions.put(handlerKey, handlerExecution);
         log.info("Mapped {} to {}", handlerKey, handlerExecution);
     }
 
-    private void validateDuplicateHanderKey(HandlerKey handlerKey) {
+    private void validateDuplicateHandlerKey(HandlerKey handlerKey) {
         if (handlerExecutions.containsKey(handlerKey)) {
             throw new IllegalStateException("중복된 핸들러 매핑 정보입니다.");
         }

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/AnnotationHandlerMappingAdaptor.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/AnnotationHandlerMappingAdaptor.java
@@ -1,0 +1,23 @@
+package com.interface21.webmvc.servlet.mvc.tobe;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public class AnnotationHandlerMappingAdaptor implements HandlerMapping {
+
+    private final AnnotationHandlerMapping annotationHandlerMapping;
+
+    public AnnotationHandlerMappingAdaptor(AnnotationHandlerMapping annotationHandlerMapping) {
+        this.annotationHandlerMapping = annotationHandlerMapping;
+    }
+
+    @Override
+    public void initialize() {
+        annotationHandlerMapping.initialize();
+    }
+
+    @Override
+    public HandlerAdaptor getHandler(HttpServletRequest request) {
+        Object handler = annotationHandlerMapping.getHandler(request);
+        return new AnnotationHandlerAdaptor(handler);
+    }
+}

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/CompositeHandlerMapping.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/CompositeHandlerMapping.java
@@ -3,6 +3,7 @@ package com.interface21.webmvc.servlet.mvc.tobe;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 public class CompositeHandlerMapping implements HandlerMapping {
 
@@ -25,12 +26,18 @@ public class CompositeHandlerMapping implements HandlerMapping {
 
     @Override
     public HandlerAdaptor getHandler(HttpServletRequest request) {
-        for (HandlerMapping handlerMapping : handlerMappings) {
-            try {
-                return handlerMapping.getHandler(request);
-            } catch (Exception ignored) {
-            }
+        return handlerMappings.stream()
+                .map(handlerMapping -> getHandler(handlerMapping, request))
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("처리할 수 없는 요청입니다."));
+    }
+
+    private HandlerAdaptor getHandler(HandlerMapping handlerMapping, HttpServletRequest request) {
+        try {
+            return handlerMapping.getHandler(request);
+        } catch (Exception e) {
+            return null;
         }
-        throw new RuntimeException("처리할 수 없는 요청입니다.");
     }
 }

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/CompositeHandlerMapping.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/CompositeHandlerMapping.java
@@ -1,0 +1,36 @@
+package com.interface21.webmvc.servlet.mvc.tobe;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Arrays;
+import java.util.List;
+
+public class CompositeHandlerMapping implements HandlerMapping {
+
+    private final List<HandlerMapping> handlerMappings;
+
+
+    public CompositeHandlerMapping(HandlerMapping... handlerMappings) {
+        this(List.copyOf(Arrays.asList(handlerMappings)));
+    }
+
+    private CompositeHandlerMapping(List<HandlerMapping> handlerMappings) {
+        this.handlerMappings = handlerMappings;
+        initialize();
+    }
+
+    @Override
+    public void initialize() {
+        handlerMappings.forEach(HandlerMapping::initialize);
+    }
+
+    @Override
+    public HandlerAdaptor getHandler(HttpServletRequest request) {
+        for (HandlerMapping handlerMapping : handlerMappings) {
+            try {
+                return handlerMapping.getHandler(request);
+            } catch (Exception ignored) {
+            }
+        }
+        throw new RuntimeException("처리할 수 없는 요청입니다.");
+    }
+}

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/CompositeHandlerMapping.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/CompositeHandlerMapping.java
@@ -9,13 +9,8 @@ public class CompositeHandlerMapping implements HandlerMapping {
 
     private final List<HandlerMapping> handlerMappings;
 
-
     public CompositeHandlerMapping(HandlerMapping... handlerMappings) {
-        this(List.copyOf(Arrays.asList(handlerMappings)));
-    }
-
-    private CompositeHandlerMapping(List<HandlerMapping> handlerMappings) {
-        this.handlerMappings = handlerMappings;
+        this.handlerMappings = List.copyOf(Arrays.asList(handlerMappings));
         initialize();
     }
 

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/HandlerAdaptor.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/HandlerAdaptor.java
@@ -1,0 +1,11 @@
+package com.interface21.webmvc.servlet.mvc.tobe;
+
+import com.interface21.webmvc.servlet.ModelAndView;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public interface HandlerAdaptor {
+    boolean isSupport(Object handler);
+
+    ModelAndView handle(final HttpServletRequest request, final HttpServletResponse response) throws Exception;
+}

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/HandlerMapping.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/HandlerMapping.java
@@ -1,0 +1,9 @@
+package com.interface21.webmvc.servlet.mvc.tobe;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public interface HandlerMapping {
+    void initialize();
+
+    HandlerAdaptor getHandler(final HttpServletRequest request);
+}

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/view/JsonView.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/view/JsonView.java
@@ -1,14 +1,18 @@
 package com.interface21.webmvc.servlet.view;
 
-import com.interface21.webmvc.servlet.View;
+import com.interface21.webmvc.servlet.AbstractView;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-
 import java.util.Map;
 
-public class JsonView implements View {
+public class JsonView extends AbstractView {
+
+    public JsonView(String viewName) {
+        super(viewName);
+    }
 
     @Override
-    public void render(final Map<String, ?> model, final HttpServletRequest request, HttpServletResponse response) throws Exception {
+    public void render(final Map<String, ?> model, final HttpServletRequest request, HttpServletResponse response)
+            throws Exception {
     }
 }

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/view/JspView.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/view/JspView.java
@@ -11,7 +11,7 @@ public class JspView extends AbstractView {
 
     private static final Logger log = LoggerFactory.getLogger(JspView.class);
 
-    public static final String REDIRECT_PREFIX = "redirect:";
+    private static final String REDIRECT_PREFIX = "redirect:";
 
     public JspView(String viewName) {
         super(viewName);

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/view/JspView.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/view/JspView.java
@@ -1,22 +1,20 @@
 package com.interface21.webmvc.servlet.view;
 
-import com.interface21.webmvc.servlet.View;
+import com.interface21.webmvc.servlet.AbstractView;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class JspView implements View {
+public class JspView extends AbstractView {
 
     private static final Logger log = LoggerFactory.getLogger(JspView.class);
 
     public static final String REDIRECT_PREFIX = "redirect:";
 
-    private final String viewName;
-
     public JspView(String viewName) {
-        this.viewName = viewName;
+        super(viewName);
     }
 
     @Override

--- a/mvc/src/main/resources/META-INF/services/jakarta.servlet.ServletContainerInitializer
+++ b/mvc/src/main/resources/META-INF/services/jakarta.servlet.ServletContainerInitializer
@@ -1,1 +1,2 @@
 com.interface21.web.SpringServletContainerInitializer
+# https://jakarta.ee/specifications/servlet/5.0/apidocs/jakarta/servlet/servletcontainerinitializer


### PR DESCRIPTION
안녕하세요 제리! 생각보다 작업해야 할 것이 적어서 빠르게 할 수 있었어요. 이번 PR에는 제가 학습한 서블릿의 동작에 대해서도 같이 서술해 볼게요!

## 서블릿 컨테이너의 생성

서블릿 스펙에선 서블릿은 웹 요청을 처리하는 역할이고, 서블릿 컨테이너는 이런 서블릿들을 적절한 시점에 생성하고 사용하고 파괴하는 등 서블릿을 관리하는 객체에요. 즉, 모든 서블릿이 생성되기 전에 서블릿 컨테이너가 먼저 생성되야 합니다.

서블릿 컨테이너를 생성하는 방법은 2가지가 있습니다.
1. xml에 서블릿, 필터, 리스너, 매핑 정보등을 기술하는 방법
2. `ServletContainerInitializer` 인터페이스 구현체를 사용하는 방법

Servlet 3.0 이전 버전에서는 첫번째 방법만 가능했어요. `ServletContainerInitializer`의 구현체를 만들고, 구현체의 패키지를 포함한 클래스 이름을
`META-INF/services/jakarta.servlet.ServletContainerInitializer` 라는 파일에 적으면 웹 어플리케이션이 구동되면서 자연스럽게 구현체가 동작해요. (출처 : https://jakarta.ee/specifications/servlet/5.0/apidocs/jakarta/servlet/servletcontainerinitializer)

우리 코드에서는 `SpringServletContainerInitializer` 가 `ServletContainerInitializer`의 구현체에요. 

`SpringServletContainerInitializer`가 동작하면 자체적으로 정의한 `WebApplicationInitializer` 인터페이스의 구현체(`DispatcherServletInitializer`)를 인식해 `public void onStartup(Set<Class<?>> webAppInitializerClasses, ServletContext servletContext)` 메서드의 첫번째 매개변수로 넣어주게 됩니다. 

이렇게 동작하는 이유는 `@HandlesTypes(WebApplicationInitializer.class)` 를`SpringServletContainerInitializer`에 붙여줬기 때문입니다.

최종적으로 `DispatcherServletInitializer`가 `DispatcherServlet`을 생성해 서블릿 컨테이너에 등록합니다.

## 미션에서 구현해야 했던 작업

결국 제가 해야 했던 작업은 `DispatcherServlet` 내에서 1단계에서 만든 프레임워크를 사용하게 하는 것이었습니다. 굳이 추가적인 클래스나 인터페이스를 추가하지 않아도 될 것이라 생각해 간단하게 작업했습니다.

만약, 실제 상황을 생각해 기존의 인터페이스 기반 MVC 프레임워크와 어노테이션 기반 MVC 프레임워크 사이의 어뎁터 레이어를 추가하기를 원하시면 작업해서 반영하겠습니다!